### PR TITLE
Prevent prisma disconnection from running more than once

### DIFF
--- a/src/executable/schema.ts
+++ b/src/executable/schema.ts
@@ -24,7 +24,7 @@ async function execute(
       try {
         await prisma.$queryRawUnsafe(query);
       } catch (e) {
-        await prisma.$disconnect();
+        break;
       }
     await prisma.$disconnect();
   } catch (err) {


### PR DESCRIPTION
# in English
It's a minor change, but I plan to leave a review for at least one repository every day. When running the `schema.ts` file with the `npm run schema $user $password` command, if an error occurs, Prisma disconnects. If it has already disconnected, there is no need to disconnect again outside the loop, so I made it end immediately with a break.

Starting tomorrow, I will review the API. There are a total of 136 TEST files, so it is expected to take a considerable amount of time to review all of them. I will start with `sales`.

This PR is a nominal PR to indicate the scope of the review. After checking the content, you can reject it if necessary. If there is nothing to review, I will only add the reviewed scope to the README.

# in Korean
별 거 아닌 수정이지만, 하루에 한 가지 이상 레포에 대한 리뷰를 남기고자 합니다.
`npm run schema $user $password` 명령어로 `schema.ts` 파일을 실행할 때 에러가 발생한다면 prisma는 disconnect 됩니다.
이미 끊긴 경우 for문 바깥쪽에서 다시 한번 연결을 끊을 필요가 없기 때문에 break로 즉시 끝내게 했습니다.

내일부터는 API를 보도록 하겠습니다.
TEST 파일이 총 136개이니 전체를 보는 데에는 상당한 시간이 걸릴 것으로 예상됩니다.
`sales`부터 시작하겠습니다.

이 PR은 명목 상의 PR이며 리뷰 범위를 나타내기 위한 것입니다.
내용을 확인 후에는 reject 하셔도 되며, 리뷰할 내용이 없는 경우에는 README에 리뷰한 범위만 추가하도록 하겠습니다.

