### PR TITLE
Add dependabot automerge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,13 +29,13 @@ jobs:
         run: pnpm install
 
       - name: Compile Backend-Server
-        run: npm run build
+        run: pnpm run build
 
       - name: Validate through EsLint
-        run: npm run eslint
+        run: pnpm run eslint
 
       - name: Create DB Schema
-        run: npm run schema postgres root
+        run: pnpm run schema postgres root
 
       - name: Test Backend-Server
-        run: npm run test -- --reset true --simultaneous 16
+        run: pnpm run test --reset true --simultaneous 16

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -7,6 +7,7 @@ on:
     types: [opened, synchronize]
     paths:
       - "package.json"
+      - "packages/api/package.json"
 
 jobs:
   build-and-merge:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,57 @@
+name: "Dependabot PR Build & Automerge"
+
+on:
+  pull_request:
+    branches:
+      - master
+    types: [opened, synchronize]
+    paths:
+      - "package.json"
+
+jobs:
+  build-and-merge:
+    if: github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    services:
+      postgres:
+        image: postgis/postgis:16-3.4
+        env:
+          POSTGRES_PASSWORD: root
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Compile Backend-Server
+        run: pnpm run build
+
+      - name: Create DB Schema
+        run: pnpm run schema postgres root
+
+      - name: Test Backend-Server
+        run: pnpm run test --reset true --simultaneous 16
+
+      - name: Merge Dependabot PRs
+        run: |
+          gh pr merge "$PR_URL" --auto --squash
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on PR
+        run: |
+          gh pr comment "$PR_URL" --body "Dependabot PR merged"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -16,43 +16,10 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    services:
-      postgres:
-        image: postgis/postgis:16-3.4
-        env:
-          POSTGRES_PASSWORD: root
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-      - uses: pnpm/action-setup@v2
-        with:
-          version: 8
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Compile Backend-Server
-        run: pnpm run build
-
-      - name: Create DB Schema
-        run: pnpm run schema postgres root
-
-      - name: Test Backend-Server
-        run: pnpm run test --reset true --simultaneous 16
-
-      - name: Merge Dependabot PRs
-        run: |
-          gh pr merge "$PR_URL" --auto --squash
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Comment on PR
         run: |
-          gh pr comment "$PR_URL" --body "Dependabot PR merged"
+          gh pr comment "$PR_URL" --body "@dependabot merge"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes changes to the GitHub workflows to standardize the package manager used and add a new workflow for Dependabot PRs. The most important changes include switching from `npm` to `pnpm` in the build workflow and adding a new workflow for automatically building and merging Dependabot PRs.

Standardization of package manager:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L32-R41): Replaced `npm` commands with `pnpm` commands for installing dependencies, building the backend server, validating through EsLint, creating the DB schema, and testing the backend server.

New workflow for Dependabot PRs:

* [`.github/workflows/dependabot-automerge.yml`](diffhunk://#diff-fcefab6ea3bce275c9f1fa2dd12848b30a37e55f9eb4dbd8331959d9df0c1499R1-R57): Added a new workflow that triggers on pull requests to the master branch made by Dependabot, installs dependencies, compiles the backend server, creates the DB schema, tests the backend server, merges the PR, and comments on the PR.