### PR TITLE
No more type tag comments on prisma

### DIFF
--- a/prisma/schema/schema-01-articles.prisma
+++ b/prisma/schema/schema-01-articles.prisma
@@ -12,28 +12,19 @@ model attachment_files {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// File name, except extension.
   ///
   /// If there's file `.gitignore`, then its name is an empty string.
-  ///
-  /// @maxLength 255
   name String @db.VarChar
 
   /// Extension.
   ///
   /// Possible to omit like `README` case.
-  ///
-  /// @minLength 1
-  /// @maxLength 8
   extension String? @db.VarChar
 
   /// URL path of the real file.
-  ///
-  /// @format uri
   url String @db.VarChar(1024)
 
   /// Creation time of record.
@@ -76,8 +67,6 @@ model attachment_files {
 /// @author Samchon
 model bbs_articles {
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Creation time of article.
@@ -96,8 +85,6 @@ model bbs_articles {
   ///
   /// It is created for the first time when an article is created, and is
   /// accumulated every time the article is modified.
-  ///
-  /// @minItems 1
   snapshots bbs_article_snapshots[]
 
   /// List of comments.
@@ -126,13 +113,9 @@ model bbs_article_snapshots {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belong article's {@link bbs_articles.id}
-  ///
-  /// @format uuid
   bbs_article_id String @db.Uuid
 
   /// Format of body.
@@ -187,23 +170,15 @@ model bbs_article_snapshot_files {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged snapshot's {@link bbs_article_snapshots.id}
-  ///
-  /// @format uuid
   bbs_article_snapshot_id String @db.Uuid
 
   /// Belonged file's {@link attachment_files.id}
-  ///
-  /// @format uuid
   attachment_file_id String @db.Uuid
 
   /// Sequence of attachment file in the snapshot.
-  ///
-  /// @format int
   sequence Int @db.Integer
 
   //----
@@ -241,20 +216,14 @@ model bbs_article_comments {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged article's {@link bbs_articles.id}
-  /// 
-  /// @format uuid
   bbs_article_id String @db.Uuid
 
   /// Parent comment's {@link bbs_article_comments.id}
   ///
   /// Used to express the hierarchical reply structure.
-  ///
-  /// @format uuid
   parent_id String? @db.Uuid
 
   /// Creation time of comment.
@@ -286,8 +255,6 @@ model bbs_article_comments {
   ///
   /// It is created for the first time when a comment is created, and is
   /// accumulated every time the comment is modified.
-  ///
-  /// @minItems 1
   snapshots  bbs_article_comment_snapshots[]
   of_inquiry shopping_sale_snapshot_inquiry_comments?
 
@@ -309,13 +276,9 @@ model bbs_article_comment_snapshots {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged article's {@link bbs_article_comments.id}
-  ///
-  /// @format uuid
   bbs_article_comment_id String @db.Uuid
 
   /// Format of content body.
@@ -357,25 +320,17 @@ model bbs_article_comment_snapshot_files {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged snapshot's {@link bbs_article_comment_snapshots.id}
-  ///
-  /// @format uuid
   bbs_article_comment_snapshot_id String @db.Uuid
 
   /// Belonged file's {@link attachment_files.id}
-  ///
-  /// @format uuid
   attachment_file_id String @db.Uuid
 
   /// Sequence order.
   ///
   /// Sequence order of the attached file in the belonged snapshot.
-  ///
-  /// @type int
   sequence Int @db.Integer
 
   //----

--- a/prisma/schema/schema-02-systematic.prisma
+++ b/prisma/schema/schema-02-systematic.prisma
@@ -15,8 +15,6 @@ model shopping_channels {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Identifier code.
@@ -86,20 +84,14 @@ model shopping_channel_categories {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged channel's {@link shopping_channels.id}.
-  ///
-  /// @format uuid
   shopping_channel_id String @db.Uuid
 
   /// Parent category's {@link shopping_channel_categories.id}.
   ///
   /// Only when the category is a subcategory of another one.
-  ///
-  /// @format uuid
   parent_id String? @db.Uuid
 
   /// Identifier code.
@@ -152,8 +144,6 @@ model shopping_sections {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Identifier code.

--- a/prisma/schema/schema-03-actors.prisma
+++ b/prisma/schema/schema-03-actors.prisma
@@ -36,47 +36,31 @@ model shopping_customers {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged channel's {@link shopping_channels.id}
-  ///
-  /// @format uuid
   shopping_channel_id String @db.Uuid /// @format uuid
 
   /// Belonged member's {@link shopping_members.id}
-  ///
-  /// @format uuid
   shopping_member_id String? @db.Uuid /// @format uuid
 
   /// Belonged external service user's {@link shopping_external_users.id}
-  ///
-  /// @format uuid
   shopping_external_user_id String? @db.Uuid /// @format uuid
 
   /// Belonged citizen's {@link shopping_citizens.id}
-  ///
-  /// @format uuid
   shopping_citizen_id String? @db.Uuid /// @format uuid
 
   /// Connection URL.
   ///
   /// {@link window.location.href}
-  ///
-  /// @format uri
   href String @db.VarChar(1024)
 
   /// Referrer URL.
   ///
   /// {@link window.document.referrer}
-  ///
-  /// @format uri
   referrer String? @db.VarChar(1024)
 
   /// IP address,
-  ///
-  /// @pattern ((^\s*((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))\s*$)|(^\s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?\s*$))
   ip String @db.VarChar
 
   /// Creation time of record.
@@ -156,8 +140,6 @@ model shopping_external_users {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged channel's {@link shopping_channels.id}
@@ -231,8 +213,6 @@ model shopping_citizens {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged channel's {@link shopping_channels.id}
@@ -240,13 +220,9 @@ model shopping_citizens {
   /// This is to manage personal information separately for each channel, 
   /// and also to recognize cases where the same citizen is authenticated 
   /// through different channels.
-  ///
-  /// @format uuid
   shopping_channel_id String? @db.Uuid
 
   /// Mobile phone number.
-  ///
-  /// @pattern ^[0-9]*$
   mobile String @db.VarChar
 
   /// Real name, or equivalent name identifiable.
@@ -309,18 +285,12 @@ model shopping_members {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged channel's {@link shopping_channels.id}
-  ///
-  /// @format uuid
   shopping_channel_id String @db.Uuid
 
   /// Belonged citizen's {@link shopping_citizens.id}
-  ///
-  /// @format uuid
   shopping_citizen_id String? @db.Uuid
 
   /// Nickname.
@@ -377,7 +347,6 @@ model shopping_member_emails {
   //----
   // COLUMNS
   //----
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged channel's {@link shopping_channels.id}
@@ -385,18 +354,13 @@ model shopping_member_emails {
   /// Duplicated attribute with {@link shopping_members.channel_id}, but
   /// just denormalized for composing unique constraint.
   ///
-  /// @format uuid
   /// @hidden
   shopping_channel_id String @db.Uuid
 
   /// Belonged member's {@link shopping_members.id}
-  /// 
-  /// @format uuid
   shopping_member_id String @db.Uuid
 
   /// Email address.
-  ///
-  /// @format email
   value String @db.VarChar
 
   /// Creation time of record.
@@ -431,13 +395,9 @@ model shopping_sellers {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged member's {@link shopping_members.id}.
-  ///
-  /// @format uuid
   shopping_member_id String @db.Uuid
 
   /// Creation time of record.
@@ -481,13 +441,9 @@ model shopping_administrators {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged member's {@link shopping_members.id}.
-  ///
-  /// @format uuid
   shopping_member_id String @db.Uuid
 
   /// Creation time of record.
@@ -522,8 +478,6 @@ model shopping_addresses {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Mobile number.

--- a/prisma/schema/schema-04-sales.prisma
+++ b/prisma/schema/schema-04-sales.prisma
@@ -24,18 +24,12 @@ model shopping_sales {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged section's {@link shopping_sections.id}
-  ///
-  /// @format uuid
   shopping_section_id String @db.Uuid
 
   /// Belonged seller's {@link shopping_customers.id}
-  ///
-  /// @format uuid
   shopping_seller_customer_id String @db.Uuid
 
   /// Creation time of record.
@@ -116,13 +110,9 @@ model shopping_sale_snapshots {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged sale's {@link shopping_sales.id}
-  ///
-  /// @format uuid
   shopping_sale_id String @db.Uuid
 
   /// Creation time of record.
@@ -189,13 +179,9 @@ model shopping_sale_snapshot_units {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged snapshot's {@link shopping_sale_snapshots.id}
-  ///
-  /// @format uuid
   shopping_sale_snapshot_id String @db.Uuid
 
   /// Representative name of the unit.
@@ -271,13 +257,9 @@ model shopping_sale_snapshot_unit_options {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged unit's {@link shopping_sale_snapshot_units.id}
-  ///
-  /// @format uuid
   shopping_sale_snapshot_unit_id String @db.Uuid
 
   /// Name of the option.
@@ -304,8 +286,6 @@ model shopping_sale_snapshot_unit_options {
   variable Boolean @db.Boolean
 
   /// Sequence order in belonged unit.
-  ///
-  /// @type int
   sequence Int @db.Integer
 
   //----
@@ -344,13 +324,9 @@ model shopping_sale_snapshot_unit_option_candidates {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged option's {@link shopping_sale_snapshot_unit_options.id}
-  ///
-  /// @format uuid
   shopping_sale_snapshot_unit_option_id String @db.Uuid
 
   /// Representative name of candidate value.
@@ -407,13 +383,9 @@ model shopping_sale_snapshot_unit_stocks {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged unit's {@link shopping_sale_snapshot_units.id}
-  ///
-  /// @format uuid
   shopping_sale_snapshot_unit_id String @db.Uuid
 
   /// Name of the final stock.
@@ -424,13 +396,9 @@ model shopping_sale_snapshot_unit_stocks {
   /// This is not real price to pay, but just a nominal price to show.
   /// If this value is greater than the `real_price`, it would be shown
   /// like seller is giving a discount.
-  ///
-  /// @minimum 0
   nominal_price Float @db.DoublePrecision
 
   /// Real price to pay.
-  ///
-  /// @minimum 0
   real_price Float @db.DoublePrecision
 
   /// Initial inventory quantity.
@@ -439,8 +407,6 @@ model shopping_sale_snapshot_unit_stocks {
   /// be sold anymore, because of out of stock. In that case, the seller can
   /// supplement the inventory quantity by registering some 
   /// {@link shopping_sale_snapshot_unit_stock_supplements} records.
-  ///
-  /// @minimum 0
   quantity Int
 
   /// Sequence order in belonged unit.
@@ -487,23 +453,15 @@ model shopping_sale_snapshot_unit_stock_choices {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged stock's {@link shopping_sale_snapshot_unit_stocks.id}
-  /// 
-  /// @format uuid
   shopping_sale_snapshot_unit_stock_id String @db.Uuid
 
   /// Belonged option's {@link shopping_sale_snapshot_unit_options.id}
-  ///
-  /// @format uuid
   shopping_sale_snapshot_unit_option_id String @db.Uuid
 
   /// Belonged candidate's {@link shopping_sale_snapshot_unit_option_candidates.id}
-  ///
-  /// @format uuid
   shopping_sale_snapshot_unit_option_candidate_id String @db.Uuid
 
   /// Sequence order in belonged stock.
@@ -543,13 +501,9 @@ model shopping_sale_snapshot_unit_stock_supplements {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged stock's {@link shopping_sale_snapshot_unit_stocks.id}
-  ///
-  /// @format uuid
   shopping_sale_snapshot_unit_stock_id String @db.Uuid
 
   /// Supplemented inventory quantity.
@@ -588,18 +542,12 @@ model shopping_sale_snapshot_categories {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged snapshot's {@link shopping_sale_snapshots.id}
-  ///
-  /// @format uuid
   shopping_sale_snapshot_id String @db.Uuid
 
   /// Belonged category's {@link shopping_channel_categories.id}
-  ///
-  /// @format uuid
   shopping_channel_category_id String @db.Uuid
 
   /// Sequence order in belonged snapshot.
@@ -628,13 +576,9 @@ model shopping_sale_snapshot_contents {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged snapshot's {@link shopping_sale_snapshots.id}
-  ///
-  /// @format uuid
   shopping_sale_snapshot_id String @db.Uuid
 
   /// Title of the content.

--- a/prisma/schema/schema-05-carts.prisma
+++ b/prisma/schema/schema-05-carts.prisma
@@ -23,13 +23,9 @@ model shopping_carts {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged customer's {@link shopping_customers.id}
-  ///
-  /// @format uuid
   shopping_customer_id String @db.Uuid
 
   /// Type of the cart creator.
@@ -86,26 +82,17 @@ model shopping_cart_commodities {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged cart's {@link shopping_carts.id}
-  ///
-  /// @format uuid
   shopping_cart_id String @db.Uuid
 
   /// Target snapshot's {@link shopping_sale_snapshots.id}
-  ///
-  /// @format uuid
   shopping_sale_snapshot_id String @db.Uuid
 
   /// Volume count.
   ///
   /// The value multiplied to {@link shopping_cart_commodity_stocks.quantity}.
-  ///
-  /// @format uint 
-  /// @minimum 1
   volume Int @db.Integer
 
   /// Creation time of record.
@@ -174,34 +161,21 @@ model shopping_cart_commodity_stocks {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged commodity's {@link shopping_cart_commodities.id}
-  ///
-  /// @format uuid
   shopping_cart_commodity_id String @db.Uuid
 
   /// Target unit's {@link shopping_sale_snapshot_units.id}
-  ///
-  /// @format uuid
   shopping_sale_snapshot_unit_id String @db.Uuid
 
   /// Target final stock's {@link shopping_sale_snapshot_unit_stocks.id}
-  ///
-  /// @format uuid
   shopping_sale_snapshot_unit_stock_id String @db.Uuid
 
   /// Quantity count.
-  ///
-  /// @type uint 
-  /// @minimum 1
   quantity Int @db.Integer
 
   /// Sequence order in belonged cart commodity.
-  ///
-  /// @type int
   sequence Int @db.Integer
 
   //----
@@ -249,31 +223,21 @@ model shopping_cart_commodity_stock_choices {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged cart-commodity-stock's {@link shopping_cart_commodity_stocks.id}
-  ///
-  /// @format uuid
   shopping_cart_commodity_stock_id String @db.Uuid
 
   /// Target option's {@link shopping_sale_snapshot_unit_options.id}
-  ///
-  /// @format uuid
   shopping_sale_snapshot_unit_option_id String @db.Uuid
 
   /// Selected candidate's {@link shopping_sale_snapshot_unit_option_candidates.id}
-  ///
-  /// @format uuid
   shopping_sale_snapshot_unit_option_candidate_id String? @db.Uuid
 
   /// User-written value for descriptive option.
   value String? @db.VarChar
 
   /// Sequence order in belonged cart-commodity-stock.
-  ///
-  /// @type int
   sequence Int @db.Integer
 
   //----

--- a/prisma/schema/schema-06-orders.prisma
+++ b/prisma/schema/schema-06-orders.prisma
@@ -28,36 +28,24 @@ model shopping_orders {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged customer's {@link shopping_customers.id}
-  ///
-  /// @format uuid
   shopping_customer_id String @db.Uuid
 
   /// Target address' {@link shopping_addresses.id}
-  ///
-  /// @format uuid
   shopping_address_id String? @db.Uuid
 
   /// Representative name of the order.
   name String @db.VarChar
 
   /// Amount of cash payment.
-  ///
-  /// @minimum 0
   cash Float @db.DoublePrecision
 
   /// Amount of deposit payment instead of cash.
-  ///
-  /// @minimum 0
   deposit Float @db.DoublePrecision
 
   /// Amount of mileage payment instead of cash.
-  ///
-  /// @minimum 0
   mileage Float @db.DoublePrecision
 
   /// Creation time of record.
@@ -127,18 +115,12 @@ model shopping_order_goods {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged order's {@link shopping_orders.id}
-  /// 
-  /// @format uuid
   shopping_order_id String @db.Uuid
 
   /// Belonged cart commodity's {@link shopping_cart_commodities.id}
-  ///
-  /// @format uuid
   shopping_cart_commodity_id String @db.Uuid
 
   /// Belonged seller's {@link shopping_sellers.id}
@@ -146,7 +128,6 @@ model shopping_order_goods {
   /// It can be computed by referencing related {@link shopping_sales},
   /// but denormalized for performance reason.
   ///
-  /// @format uuid
   /// @hidden
   shopping_seller_id String @db.Uuid
 
@@ -156,14 +137,9 @@ model shopping_order_goods {
   /// It's purpose is exactly same with {@link shopping_cart_commodities.volume},
   /// but rewritten because the {@link shopping_cart_commodities} records are
   /// reusable until payment.
-  ///
-  /// @format uint 
-  /// @minimum 1
   volume Int @db.Integer
 
   /// Sequence order(?) in belonged order.
-  ///
-  /// @format int
   sequence Int @db.Integer
 
   /// Confirmation time of order good.
@@ -224,13 +200,9 @@ model shopping_order_publishes {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged order's {@link shopping_orders.id}
-  ///
-  /// @format uuid
   shopping_order_id String @db.Uuid
 
   /// Target address' {@link shopping_addresses.id}
@@ -238,8 +210,6 @@ model shopping_order_publishes {
   /// The place to receive the goods. For reference, the address information
   /// also has an information of receiver, and it can be different with the
   /// customer who has ordered.
-  ///
-  /// @format uuid
   shopping_address_id String @db.Uuid
 
   /// Password for encryption.
@@ -306,13 +276,9 @@ model shopping_deliveries {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged seller's {@link shopping_sellers.id}
-  ///
-  /// @format uuid
   shopping_seller_customer_id String @db.Uuid
 
   /// Creation time of record.
@@ -351,40 +317,26 @@ model shopping_delivery_pieces {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged delivery's {@link shopping_deliveries.id}
-  ///
-  /// @format uuid
   shopping_delivery_id String @db.Uuid
 
   /// Target order-publish'es {@link shopping_order_publishes.id}
-  ///
-  /// @format uuid 
   shopping_order_publish_id String @db.Uuid
 
   /// Target good's {@link shopping_order_goods.id}
-  ///
-  /// @format uuid
   shopping_order_good_id String @db.Uuid
 
   /// Target stock's {@link shopping_sale_snapshot_unit_stocks.id}
-  ///
-  /// @format uuid
   shopping_sale_snapshot_unit_stock_id String @db.Uuid
 
   /// Quantity count.
   ///
   /// It can be precision value to express split shipping.
-  ///
-  /// @exclusiveMinimum 0
   quantity Float @db.DoublePrecision
 
   /// Sequence order in belonged delivery.
-  ///
-  /// @type int
   sequence Int @db.Integer
 
   //----
@@ -408,13 +360,9 @@ model shopping_delivery_shippers {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged delivery's {@link shopping_deliveries.id}
-  ///
-  /// @format uuid
   shopping_delivery_id String @db.Uuid
 
   /// Mobile number of shipper.
@@ -450,11 +398,9 @@ model shopping_delivery_journeys {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
-  /// @format uuid
+  /// Belonged delivery's {@link shopping_deliveries.id}
   shopping_delivery_id String @db.Uuid
 
   /// Type of journey.

--- a/prisma/schema/schema-07-coupons.prisma
+++ b/prisma/schema/schema-07-coupons.prisma
@@ -31,13 +31,9 @@
 /// @author Samchon
 model shopping_coupons {
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged administrator or seller's {@link shopping_customers.id}
-  ///
-  /// @format uuid
   shopping_customer_id String @db.Uuid
 
   /// Type of the coupon creator.
@@ -80,16 +76,12 @@ model shopping_coupons {
   /// Discount value.
   ///
   /// If `unit` is percent, range of value is limited from 0 to 100.
-  ///
-  /// @exclusiveMinimum 0
   value Float @db.DoublePrecision
 
   /// Minimum purchase amount for discount.
   /// 
   /// When setting this value, discount coupons cannot be applied to 
   /// order totals that are less than this value.
-  ///
-  /// @exclusiveMinimum 0
   threshold Float? @db.DoublePrecision
 
   /// Maximum amount available for discount.
@@ -125,9 +117,6 @@ model shopping_coupons {
   /// 
   /// In other words, the concept of N coupons being issued on a first-come, 
   /// first-served basis is created.
-  ///
-  /// @format uint 
-  /// @minimum 1
   volume Int? @db.Integer
 
   /// Limited quantity issued per person.
@@ -138,9 +127,6 @@ model shopping_coupons {
   /// 
   /// Of course, by assigning a value of N, the total amount issued to the 
   /// same citizen can be limited.
-  ///
-  /// @format uint 
-  /// @minimum 1
   volume_per_citizen Int? @db.Integer
 
   /// Expiration day(s) value.
@@ -149,9 +135,6 @@ model shopping_coupons {
   /// 
   /// Therefore, customers must use the ticket within N days, if possible, 
   /// from the time it is issued.
-  ///
-  /// @format uint 
-  /// @minimum 1
   expired_in Int? @db.Integer
 
   /// Expiration date.
@@ -237,13 +220,9 @@ model shopping_coupons {
 /// @author Samchon
 model shopping_coupon_criterias {
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged coupon's {@link shopping_coupons.id}
-  ///
-  /// @format uuid
   shopping_coupon_id String @db.Uuid
 
   /// Type of criteria.
@@ -258,8 +237,6 @@ model shopping_coupon_criterias {
   direction String @db.VarChar
 
   /// Sequence order in belonged coupon.
-  ///
-  /// @format int
   sequence Int @db.Integer
 
   //----
@@ -293,13 +270,9 @@ model shopping_coupon_criterias {
 /// @author Samchon
 model shopping_coupon_section_criterias {
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Target section's {@link shopping_coupon_criterias.id}
-  ///
-  /// @format uuid
   shopping_section_id String @db.Uuid
 
   //----
@@ -332,13 +305,9 @@ model shopping_coupon_section_criterias {
 /// @author Samchon
 model shopping_coupon_seller_criterias {
   /// PK + FK.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Target seller's {@link shopping_sellers.id}
-  ///
-  /// @format uuid
   shopping_seller_id String @db.Uuid
 
   //----
@@ -369,13 +338,9 @@ model shopping_coupon_seller_criterias {
 /// @author Samchon
 model shopping_coupon_sale_criterias {
   /// PK + FK.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Target sale's {@link shopping_sales.id}
-  ///
-  /// @format uuid
   shopping_sale_id String @db.Uuid
 
   //----
@@ -406,8 +371,6 @@ model shopping_coupon_sale_criterias {
 /// @author Samchon
 model shopping_coupon_funnel_criterias {
   /// PK + FK.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// What kind of funnel is it?
@@ -445,25 +408,17 @@ model shopping_coupon_funnel_criterias {
 /// @author Samchon
 model shopping_coupon_tickets {
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged customer's {@link shopping_customers.id}
-  ///
-  /// @format uuid
   shopping_customer_id String @db.Uuid
 
   /// Belonged coupon's {@link shopping_coupons.id}
-  ///
-  /// @format uuid
   shopping_coupon_id String @db.Uuid
 
   /// Belonged disposable's {@link shopping_coupon_disposables.id}
   ///
   /// Only when current ticket be issued from one-time code.
-  ///
-  /// @format uuid
   shopping_coupon_disposable_id String? @db.Uuid
 
   /// Creation time of record.
@@ -516,23 +471,15 @@ model shopping_coupon_tickets {
 /// @author Samchon
 model shopping_coupon_ticket_payments {
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged ticket's {@link shopping_coupon_tickets.id}
-  ///
-  /// @format uuid
   shopping_coupon_ticket_id String @db.Uuid
 
   /// Target order's {@link shopping_orders.id}
-  ///
-  /// @format uuid
   shopping_order_id String @db.Uuid
 
   /// Sequence order(?) in belonged order.
-  ///
-  /// @format int
   sequence Int @db.Integer
 
   /// Creation time of record.
@@ -573,13 +520,9 @@ model shopping_coupon_ticket_payments {
 /// @author Samchon
 model shopping_coupon_disposables {
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged coupon's {@link shopping_coupons.id}
-  ///
-  /// @format uuid
   shopping_coupon_id String @db.Uuid
 
   /// Identifier code.

--- a/prisma/schema/schema-08-coin.prisma
+++ b/prisma/schema/schema-08-coin.prisma
@@ -13,8 +13,6 @@ model shopping_deposits {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Identifier code.
@@ -63,23 +61,15 @@ model shopping_deposit_histories {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged metadata's {@link shopping_deposits.id}
-  ///
-  /// @format uuid
   shopping_deposit_id String @db.Uuid
 
   /// Belonged citizen's {@link shopping_citizens.id}
-  ///
-  /// @format uuid
   shopping_citizen_id String @db.Uuid
 
-  /// The source record occurred deposit/outcome. 
-  ///
-  /// @format uuid
+  /// The source record occurred deposit/outcome.
   source_id String @db.Uuid
 
   /// Income/outcome amount of deposit.
@@ -89,8 +79,6 @@ model shopping_deposit_histories {
   /// If you want to express the figures for incomes and outcomes as 
   /// positive/negative numbers, you can also multiply this field value by 
   /// the attributed {@link shopping_deposits.direction} value.
-  ///
-  /// @minimum 0
   value Float @db.DoublePrecision
 
   /// Balance value.
@@ -134,18 +122,12 @@ model shopping_deposit_charges {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged metadata's {@link shopping_deposits.id}
-  ///
-  /// @format uuid
   shopping_customer_id String @db.Uuid
 
   /// Charging amount.
-  ///
-  /// @exclusiveMinimum 0
   value Float @db.DoublePrecision
 
   /// Creation time of record.
@@ -187,13 +169,9 @@ model shopping_deposit_charge_publishes {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged charge appliance's {@link shopping_deposit_charges.id}
-  ///
-  /// @format uuid
   shopping_deposit_charge_id String @db.Uuid
 
   /// Password for encryption.
@@ -238,8 +216,6 @@ model shopping_deposit_charge_publishes {
 /// @author Samchon
 model shopping_mileages {
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Identifier code.
@@ -259,8 +235,6 @@ model shopping_mileages {
   /// Possible to omit, and how to use this default value is up to the
   /// backend program. It is okay to use it as a default value when
   /// creating a new record, or percentage value to be applied.
-  ///
-  /// @minimum 0
   value Float? @db.DoublePrecision
 
   /// Creation time of record.
@@ -286,18 +260,12 @@ model shopping_mileage_donations {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged seller's {@link shopping_customers.id}
-  ///
-  /// @format uuid
   shopping_admin_customer_id String @db.Uuid
 
   /// Belonged citizen's {@link shopping_citizens.id}
-  ///
-  /// @format uuid
   shopping_citizen_id String @db.Uuid
 
   /// Amount of donation.
@@ -336,23 +304,15 @@ model shopping_mileage_histories {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged metadata's {@link shopping_mileages.id}
-  ///
-  /// @format uuid
   shopping_mileage_id String @db.Uuid
 
   /// Belonged citizen's {@link shopping_citizens.id}
-  ///
-  /// @format uuid
   shopping_citizen_id String @db.Uuid
 
-  /// The source record occurred income/outcome. 
-  ///
-  /// @format uuid
+  /// The source record occurred income/outcome.
   source_id String @db.Uuid
 
   /// Income/outcome amount of mileage.
@@ -362,8 +322,6 @@ model shopping_mileage_histories {
   /// If you want to express the figures for incomes and outcomes as 
   /// positive/negative numbers, you can also multiply this field value by 
   /// the attributed {@link shopping_mileages.direction} value.
-  ///
-  /// @minimum 0
   value Float @db.DoublePrecision
 
   /// Balance value.

--- a/prisma/schema/schema-09-inquiries.prisma
+++ b/prisma/schema/schema-09-inquiries.prisma
@@ -27,18 +27,12 @@ model shopping_sale_snapshot_inquiries {
   // COLUMNS
   //----
   /// PK + FK.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged snapshot's {@link shopping_sale_snapshots.id}
-  ///
-  /// @format uuid
   shopping_sale_snapshot_id String @db.Uuid
 
   /// Writer customer's {@link shopping_customers.id}
-  ///
-  /// @format uuid
   shopping_customer_id String @db.Uuid
 
   /// Type of the inquiry article.
@@ -93,8 +87,6 @@ model shopping_sale_snapshot_questions {
   // COLUMNS
   //----
   /// PK + FK.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Whether secret or not.
@@ -132,13 +124,9 @@ model shopping_sale_snapshot_reviews {
   // COLUMNS
   //----
   /// PK + FK.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged good's {@link shopping_order_goods.id}
-  ///
-  /// @format uuid
   shopping_order_good_id String @db.Uuid
 
   //----
@@ -166,14 +154,9 @@ model shopping_sale_snapshot_review_snapshots {
   // COLUMNS
   //----
   /// PK + FK.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Estimation score value.
-  ///
-  /// @minimum 0
-  /// @maximum 100
   score Float @db.DoublePrecision
 
   //----
@@ -207,18 +190,12 @@ model shopping_sale_snapshot_inquiry_answers {
   // COLUMNS
   //----
   /// PK + FK
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged inquiry's {@link shopping_sale_snapshot_inquiries.id}
-  ///
-  /// @format uuid
   shopping_sale_snapshot_inquiry_id String @db.Uuid
 
   /// Answered seller's {@link shopping_customers.id}
-  ///
-  /// @format uuid
   shopping_seller_customer_id String @db.Uuid
 
   //----
@@ -251,13 +228,9 @@ model shopping_sale_snapshot_inquiry_comments {
   // COLUMNS
   //----
   /// PK + FK
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Writer's {@link shopping_customers.id}
-  ///
-  /// @format uuid
   shopping_customer_id String @db.Uuid
 
   /// Type of the writer.

--- a/prisma/schema/schema-10-favorites.prisma
+++ b/prisma/schema/schema-10-favorites.prisma
@@ -13,8 +13,6 @@ model shopping_sale_favorites {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged customer's {@link shopping_customers.id}
@@ -62,8 +60,6 @@ model shopping_sale_snapshot_inquiry_favorites {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged customer's {@link shopping_customers.id}
@@ -112,8 +108,6 @@ model shopping_address_favorites {
   // COLUMNS
   //----
   /// Primary Key.
-  ///
-  /// @format uuid
   id String @id @db.Uuid
 
   /// Belonged customer's {@link shopping_customers.id}


### PR DESCRIPTION
This pull request removes various validation and metadata annotations from the Prisma schema files across multiple models. The changes simplify the schema by eliminating constraints such as format, length, and pattern annotations for fields like UUIDs, URLs, and other attributes. Below is a categorized summary of the most important changes:

### General Schema Simplifications:
* Removed `@format` annotations for UUID fields in models such as `attachment_files`, `bbs_articles`, `shopping_channels`, and others. These annotations were used to specify that the fields should follow the UUID format. [[1]](diffhunk://#diff-8dd4022f8a1f2d4039ef736edeca3a3436b9b3dcd8b7a6f94f05f15374a09eaeL15-L36) [[2]](diffhunk://#diff-9cfb9a0da7b643b8228db5909bb4a3ab4111045d32d77092167e4263b1aa9045L18-L19) [[3]](diffhunk://#diff-fda2f9b767602581cdeb51d42bf0cafcd6234b64625a752604152e277092e4e0L39-L79)
* Eliminated `@format uri` annotations for URL fields, such as `url` in the `attachment_files` model and `href` in the `shopping_customers` model. [[1]](diffhunk://#diff-8dd4022f8a1f2d4039ef736edeca3a3436b9b3dcd8b7a6f94f05f15374a09eaeL15-L36) [[2]](diffhunk://#diff-fda2f9b767602581cdeb51d42bf0cafcd6234b64625a752604152e277092e4e0L39-L79)
* Removed `@pattern` annotations for fields like `ip` and `mobile`, which enforced specific patterns (e.g., IPv4/IPv6 or numeric-only formats). [[1]](diffhunk://#diff-fda2f9b767602581cdeb51d42bf0cafcd6234b64625a752604152e277092e4e0L39-L79) [[2]](diffhunk://#diff-fda2f9b767602581cdeb51d42bf0cafcd6234b64625a752604152e277092e4e0L234-L249)

### Length and Range Constraints:
* Deleted `@minLength` and `@maxLength` annotations for string fields, such as `name` and `extension` in the `attachment_files` model.
* Removed `@minItems` annotations for array fields, such as `snapshots` in the `bbs_articles` and `bbs_article_comments` models. [[1]](diffhunk://#diff-8dd4022f8a1f2d4039ef736edeca3a3436b9b3dcd8b7a6f94f05f15374a09eaeL99-L100) [[2]](diffhunk://#diff-8dd4022f8a1f2d4039ef736edeca3a3436b9b3dcd8b7a6f94f05f15374a09eaeL289-L290)
* Eliminated `@minimum` annotations for numeric fields, such as `nominal_price`, `real_price`, and `quantity` in the `shopping_sale_snapshot_unit_stocks` model. [[1]](diffhunk://#diff-2a83acb98a51309bb263e13b6d1b6c3c792c4baedb949826cf7934a1fc2ad5edL427-L433) [[2]](diffhunk://#diff-2a83acb98a51309bb263e13b6d1b6c3c792c4baedb949826cf7934a1fc2ad5edL442-L443)

### Denormalization and Relationships:
* Removed `@format` annotations for relationship fields, such as `shopping_channel_id` and `shopping_member_id` in models like `shopping_customers`, `shopping_members`, and `shopping_sale_snapshots`. [[1]](diffhunk://#diff-fda2f9b767602581cdeb51d42bf0cafcd6234b64625a752604152e277092e4e0L39-L79) [[2]](diffhunk://#diff-2a83acb98a51309bb263e13b6d1b6c3c792c4baedb949826cf7934a1fc2ad5edL27-L38) [[3]](diffhunk://#diff-2a83acb98a51309bb263e13b6d1b6c3c792c4baedb949826cf7934a1fc2ad5edL119-L125)
* Deleted annotations for hierarchical relationships, such as `parent_id` in the `shopping_channel_categories` model, which previously specified the UUID format.

### Miscellaneous:
* Removed `@type int` annotations for sequence fields, such as `sequence` in the `shopping_sale_snapshot_unit_options` and `shopping_sale_snapshot_unit_stocks` models. [[1]](diffhunk://#diff-2a83acb98a51309bb263e13b6d1b6c3c792c4baedb949826cf7934a1fc2ad5edL307-L308) [[2]](diffhunk://#diff-2a83acb98a51309bb263e13b6d1b6c3c792c4baedb949826cf7934a1fc2ad5edL442-L443)
* Eliminated `@format email` annotations for email fields, such as `value` in the `shopping_member_emails` model.

These changes aim to reduce schema complexity and remove redundant or overly restrictive validations, likely to allow for greater flexibility in data handling and simplify maintenance.